### PR TITLE
remove url pathname

### DIFF
--- a/src/index.ls
+++ b/src/index.ls
@@ -89,7 +89,7 @@ function main target, from
   params = { from, target }
   parsed-base-url = url.parse graphite-base-url
   url-obj = merge parsed-base-url,
-    pathname: parsed-base-url.pathname ++ '/render'
+    pathname: '/render'
 
   curl = ->
     request it .pipe process.stdout


### PR DESCRIPTION
graphite-cli appends two slash after the URL string

`http://graphite//render`

 which is not working/not supported in carbonapi servers[https://github.com/go-graphite/carbonapi] 

This change works in both graphite-web api and carboanpi 

cc @raine 